### PR TITLE
Add BASH script to run test against a local directory.

### DIFF
--- a/runTests-dev.sh
+++ b/runTests-dev.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+runTests() {
+
+  local aTests bRunning sAppDirectory sContainerName sServerName sReportDirectory
+
+  readonly sContainerName='server'
+
+  bRunning=false
+
+  dockerStop() {
+    if [[ "${bRunning:-}" == true ]];then
+      echo ' -----> Stopping server...'
+      docker stop "${sContainerName}" > /dev/null || echo 'Could not stop server'
+      bRunning=false
+    fi
+  }
+
+  declare -a aTests=('webid-provider' 'solid-crud')
+
+  readonly sServerName="${1?Two parameter required: <name> <project-path> [report-directory]}"
+  readonly sAppDirectory="${2?Two parameter required: <name> <project-path> [report-directory]}"
+  readonly sReportDirectory="${3:-$PWD}/reports"
+
+  trap dockerStop EXIT INT TERM
+
+  echo " =====> Running test for ${sServerName} from ${sAppDirectory}"
+
+  echo ' -----> Starting server...'
+  docker run \
+    -d \
+    --name=${sContainerName} \
+    --network=testnet \
+    --rm \
+    --volume "${sAppDirectory}:/app" \
+    "${sServerName}"
+
+  bRunning=true
+
+  if [[ "${sServerName}" == 'nextcloud-server' ]]; then
+      echo ' -----> Waiting for Nextcloud server to start ...'
+      sleep 10
+      docker logs "${sContainerName}"
+      echo ' -----> Running init script for Nextcloud server ...'
+      docker exec -it --user 'www-data' "${sContainerName}" sh /init.sh
+  fi
+
+  for sTest in "${aTests[@]}"; do
+    echo " -----> Running ${sTest} tester..."
+    {
+      docker run \
+        --env-file "servers/${sServerName}/env.list" \
+        --network=testnet \
+        "${sTest}" \
+      2> "${sReportDirectory}/${sServerName}-${sTest}.txt"
+    } || true
+  done
+
+  dockerStop
+
+  echo -e "\n =====> Test results\n"
+  grep 'Tests' "${sReportDirectory}/${sServerName}"-*.txt \
+    | cut -d ':' -f1,3- | rev | cut -d '/' -f1 | rev
+}
+
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    export -f runTests
+else
+    runTests "${@}"
+    exit $?
+fi


### PR DESCRIPTION
This merge-request adds a script (based on `runTests-dev.sh`) that mounts a given local directory in the server-under-test.

This way it is trivial to run the test against a local server that is still under development.

The script requires a second parameter telling it where the directory is that should be mounted:

```
bash runTests-dev.sh 'php-solid-server' /path/to/php-solid-server
```

In comparison to the script it is based on, besides mounting a volume, this changes in this script:

- Add a shebang
- Add error options
- Add a wrapper function around the code so the script can also be sourced from other scripts
- Add a `trap` to stop the Docker container if the script only runs partially in case of errors
- Add a `grep` line to output the test results
- Change the `docker rm` call to a `--rm` flag on the `docker run` call
- Change the test runs from semi-duplicate lines to a `for` loop
- Remove the `docker build` step, as the used image is expected to already exist for development purposes